### PR TITLE
Update for new Stop and time-limited order types; add missing API calls

### DIFF
--- a/src/Coinbase/Exchange/Private.hs
+++ b/src/Coinbase/Exchange/Private.hs
@@ -18,6 +18,9 @@ module Coinbase.Exchange.Private
 
     , createTransfer
 
+    , createReport
+    , getReportStatus
+
     , module Coinbase.Exchange.Types.Private
     ) where
 
@@ -93,3 +96,13 @@ getFills moid mpid = coinbaseGet True ("/fills?" ++ oid ++ "&" ++ pid) voidBody
 createTransfer :: (MonadResource m, MonadReader ExchangeConf m, MonadError ExchangeFailure m)
                => Transfer -> m ()
 createTransfer = coinbasePost True "/transfers" . Just
+
+-- Reports
+
+createReport :: (MonadResource m, MonadReader ExchangeConf m, MonadError ExchangeFailure m)
+             => ReportRequest -> m ReportInfo
+createReport = coinbasePost True "/reports" . Just
+
+getReportStatus :: (MonadResource m, MonadReader ExchangeConf m, MonadError ExchangeFailure m)
+             => ReportId -> m ReportInfo
+getReportStatus (ReportId r) = coinbaseGet True ("/reports/" ++ toString r) voidBody

--- a/src/Coinbase/Exchange/Rest.hs
+++ b/src/Coinbase/Exchange/Rest.hs
@@ -6,6 +6,7 @@ module Coinbase.Exchange.Rest
     ( coinbaseGet
     , coinbasePost
     , coinbaseDelete
+    , coinbaseDeleteDiscardBody
     , voidBody
     ) where
 
@@ -56,11 +57,19 @@ coinbasePost :: ( ToJSON a
 coinbasePost sgn p ma = coinbaseRequest "POST" sgn p ma >>= processResponse
 
 coinbaseDelete :: ( ToJSON a
+                  , FromJSON b
                   , MonadResource m
                   , MonadReader ExchangeConf m
                   , MonadError ExchangeFailure m )
-               => Signed -> Path -> Maybe a -> m ()
-coinbaseDelete sgn p ma = coinbaseRequest "DELETE" sgn p ma >>= processEmpty
+               => Signed -> Path -> Maybe a -> m b
+coinbaseDelete sgn p ma = coinbaseRequest "DELETE" sgn p ma >>= processResponse
+
+coinbaseDeleteDiscardBody :: ( ToJSON a
+                             , MonadResource m
+                             , MonadReader ExchangeConf m
+                             , MonadError ExchangeFailure m )
+                             => Signed -> Path -> Maybe a -> m ()
+coinbaseDeleteDiscardBody sgn p ma = coinbaseRequest "DELETE" sgn p ma >>= processEmpty
 
 coinbaseRequest :: ( ToJSON a
                    , MonadResource m

--- a/src/Coinbase/Exchange/Types.hs
+++ b/src/Coinbase/Exchange/Types.hs
@@ -65,19 +65,19 @@ type Endpoint = String
 type Path     = String
 
 website :: Endpoint
-website = "https://public.sandbox.exchange.coinbase.com"
+website = "https://public.sandbox.gdax.com"
 
 sandboxRest :: Endpoint
-sandboxRest = "https://api-public.sandbox.exchange.coinbase.com"
+sandboxRest = "https://api-public.sandbox.gdax.com"
 
 sandboxSocket :: Endpoint
-sandboxSocket = "ws-feed-public.sandbox.exchange.coinbase.com"
+sandboxSocket = "ws-feed-public.sandbox.gdax.com"
 
 liveRest :: Endpoint
-liveRest = "https://api.exchange.coinbase.com"
+liveRest = "https://api.gdax.com"
 
 liveSocket :: Endpoint
-liveSocket = "ws-feed.exchange.coinbase.com"
+liveSocket = "ws-feed.gdax.com"
 
 -- Monad Stack
 

--- a/src/Coinbase/Exchange/Types/Core.hs
+++ b/src/Coinbase/Exchange/Types/Core.hs
@@ -94,6 +94,7 @@ data OrderStatus
     | Settled
     | Open
     | Pending
+    | Active
     deriving (Eq, Show, Read, Data, Typeable, Generic)
 
 instance NFData OrderStatus

--- a/test/Coinbase/Exchange/Private/Test.hs
+++ b/test/Coinbase/Exchange/Private/Test.hs
@@ -131,6 +131,7 @@ creatNewLimitOrder = do
         , noClientOid = Just $ ClientOrderId $ fromJust $ fromString "c2cc10e1-57d6-4b6f-9899-111122223d8c"
         , noPostOnly  = False
         , noTimeInForce = GoodTillCanceled
+        , noCancelAfter = Nothing
         }
 
 


### PR DESCRIPTION
Upgrade to work with Stop orders and Limit order cancel times. Also filled in some missing API calls (cancel all orders and reports).

Lastly coinbase exchange has rebranded as GDAX, with new api endpoint urls to match.
