### PR TITLE
Update URLs and verbiage for re-branding from GDAX to Coinbase Pro

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Haskell language access library for the GDAX Exchange (formerly Coinbase).
+Haskell language access library for the Coinbase Pro exchange (formerly GDAX).
 
 Allows the use of:
 

--- a/sbox/Main.hs
+++ b/sbox/Main.hs
@@ -38,11 +38,11 @@ end = Just $ parseTimeOrError True defaultTimeLocale "%FT%X%z" "2015-04-23T20:22
 withCoinbase :: Exchange a -> IO a
 withCoinbase act = do
         mgr     <- newManager tlsManagerSettings
-        tKey    <- liftM CBS.pack $ getEnv "GDAX_KEY"
-        tSecret <- liftM CBS.pack $ getEnv "GDAX_SECRET"
-        tPass   <- liftM CBS.pack $ getEnv "GDAX_PASSPHRASE"
+        tKey    <- liftM CBS.pack $ getEnv "COINBASE_PRO_KEY"
+        tSecret <- liftM CBS.pack $ getEnv "COINBASE_PRO_SECRET"
+        tPass   <- liftM CBS.pack $ getEnv "COINBASE_PRO_PASSPHRASE"
 
-        sbox    <- getEnv "GDAX_SANDBOX"
+        sbox    <- getEnv "COINBASE_PRO_SANDBOX"
         let apiType  = case sbox of
                         "FALSE" -> Live
                         "TRUE"  -> Sandbox

--- a/src/Coinbase/Exchange/Socket.hs
+++ b/src/Coinbase/Exchange/Socket.hs
@@ -1,7 +1,8 @@
 {-# LANGUAGE OverloadedStrings #-}
 
 module Coinbase.Exchange.Socket
-    ( subscribe
+    ( setHeartbeat
+    , subscribe
     , module Coinbase.Exchange.Types.Socket
     ) where
 

--- a/src/Coinbase/Exchange/Types.hs
+++ b/src/Coinbase/Exchange/Types.hs
@@ -68,19 +68,19 @@ type Endpoint = String
 type Path     = String
 
 website :: Endpoint
-website = "https://public.sandbox.gdax.com"
+website = "https://public.sandbox.pro.coinbase.com"
 
 sandboxRest :: Endpoint
-sandboxRest = "https://api-public.sandbox.gdax.com"
+sandboxRest = "https://api-public.sandbox.pro.coinbase.com"
 
 sandboxSocket :: Endpoint
-sandboxSocket = "ws-feed-public.sandbox.gdax.com"
+sandboxSocket = "ws-feed-public.sandbox.pro.coinbase.com"
 
 liveRest :: Endpoint
-liveRest = "https://api.gdax.com"
+liveRest = "https://api.pro.coinbase.com"
 
 liveSocket :: Endpoint
-liveSocket = "ws-feed.gdax.com"
+liveSocket = "ws-feed.pro.coinbase.com"
 
 -- Coinbase needs to provide real BTC transfers through the exchange API soon,
 -- making 2 API calls with 2 sets of authentication credentials is ridiculous.

--- a/src/Coinbase/Exchange/Types/Private.hs
+++ b/src/Coinbase/Exchange/Types/Private.hs
@@ -423,7 +423,7 @@ instance FromJSON Order where
                 <$> m .: "id"
                 <*> m .: "product_id"
                 <*> m .: "status"
-                <*> m .: "stp"
+                <*> m .:? "stp" .!= DecrementAndCancel
                 <*> m .: "settled"
                 <*> m .: "side"
                 <*> m .: "created_at"

--- a/src/Coinbase/Exchange/Types/Socket.hs
+++ b/src/Coinbase/Exchange/Types/Socket.hs
@@ -97,7 +97,7 @@ data ExchangeMessage
         -- Filled market orders limited by funds will not have a price but may have remaining_size
         -- Filled limit orders may have a price but not a remaining_size (assumed zero)
         -- CURRENTLY ** `remaining_size` reported in Done messages is sometimes incorrect **
-        -- This appears to be bug at GDAX. I've told them about it.
+        -- This appears to be bug at Coinbase. I've told them about it.
         , msgMaybePrice   :: Maybe Price
         , msgMaybeRemSize :: Maybe Size
         }

--- a/src/Coinbase/Exchange/Types/Socket.hs
+++ b/src/Coinbase/Exchange/Types/Socket.hs
@@ -134,10 +134,10 @@ instance NFData ExchangeMessage
 instance FromJSON ExchangeMessage where
     parseJSON (Object m) = do
         msgtype <- m .: "type"
-        -- TO DO: `HeartbeatReq` and `Subscribe` message types are missing as those are
-        -- never received by the client.
-        case (msgtype :: String) of
-            "hearbeat"-> Heartbeat
+        -- TO DO: `Subscribe` message type is missing as it is never received
+        -- by the client.
+        case (msgtype :: Text) of
+            "heartbeat"-> Heartbeat
                 <$> m .: "time"
                 <*> m .: "product_id"
                 <*> m .: "sequence"
@@ -348,3 +348,11 @@ instance ToJSON ExchangeMessage where
                     Right (ms,f) -> case ms of
                                 Nothing -> ( []            , ["funds" .= f] )
                                 Just s' -> ( ["size" .= s'], ["funds" .= f] )
+
+    toJSON Heartbeat{..} = object
+       [ "type"          .= ("heartbeat" :: Text)
+       , "time"          .= msgTime
+       , "product_id"    .= msgProductId
+       , "sequence"      .= msgSequence
+       , "last_trade_id" .= msgLastTradeId
+       ]

--- a/test/Coinbase/Exchange/Socket/Test.hs
+++ b/test/Coinbase/Exchange/Socket/Test.hs
@@ -58,10 +58,11 @@ parseSocket conf market challenge = subscribe (apiType conf) market $ \conn -> d
 -- a more thorough test would be better.
 reencodeSocket :: ExchangeConf -> [ProductId] -> IO ()
 reencodeSocket conf market = subscribe (apiType conf) market $ \conn -> do
-    sequence_ $ replicate 1000 (decodeEncode conn)
+    sequence_ $ replicate 10 (decodeEncode conn)
 
 decodeEncode :: WS.Connection -> IO ()
 decodeEncode conn = do
+    setHeartbeat True conn
     ds <- WS.receiveData conn
     let res = eitherDecode ds
     case res :: Either String ExchangeMessage of
@@ -80,6 +81,7 @@ decodeEncode conn = do
 
 receiveAndDecode :: WS.Connection -> IO ()
 receiveAndDecode conn = do
+    setHeartbeat True conn
     ds <- WS.receiveData conn
     let res = eitherDecode {- $ trace (show ds) -} ds
     case res :: Either String ExchangeMessage of

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -19,11 +19,11 @@ import qualified Coinbase.Exchange.Socket.Test     as Socket
 main :: IO ()
 main = do
         mgr     <- newManager tlsManagerSettings
-        tKey    <- liftM CBS.pack $ getEnv "GDAX_KEY"
-        tSecret <- liftM CBS.pack $ getEnv "GDAX_SECRET"
-        tPass   <- liftM CBS.pack $ getEnv "GDAX_PASSPHRASE"
+        tKey    <- liftM CBS.pack $ getEnv "COINBASE_PRO_KEY"
+        tSecret <- liftM CBS.pack $ getEnv "COINBASE_PRO_SECRET"
+        tPass   <- liftM CBS.pack $ getEnv "COINBASE_PRO_PASSPHRASE"
 
-        sbox    <- getEnv "GDAX_SANDBOX"
+        sbox    <- getEnv "COINBASE_PRO_SANDBOX"
         let apiType  = case sbox of
                         "FALSE" -> Live
                         "TRUE"  -> Sandbox


### PR DESCRIPTION
Coinbase has rebranded its exchange from "GDAX" to "Coinbase Pro" and deprecated the API endpoints at the gdax.com domain. This commit merely swaps out the deprecated URLs for their replacements and changes all references of "GDAX" to "Coinbase Pro".

Tests reveal an unrelated problem parsing order information; I'll fix that tomorrow.