### PR TITLE
Fix parsing of order info

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Haskell language access library for the GDAX Exchange (formerly Coinbase).
+Haskell language access library for the Coinbase Pro exchange (formerly GDAX).
 
 Allows the use of:
 

--- a/sbox/Main.hs
+++ b/sbox/Main.hs
@@ -38,11 +38,11 @@ end = Just $ parseTimeOrError True defaultTimeLocale "%FT%X%z" "2015-04-23T20:22
 withCoinbase :: Exchange a -> IO a
 withCoinbase act = do
         mgr     <- newManager tlsManagerSettings
-        tKey    <- liftM CBS.pack $ getEnv "GDAX_KEY"
-        tSecret <- liftM CBS.pack $ getEnv "GDAX_SECRET"
-        tPass   <- liftM CBS.pack $ getEnv "GDAX_PASSPHRASE"
+        tKey    <- liftM CBS.pack $ getEnv "COINBASE_PRO_KEY"
+        tSecret <- liftM CBS.pack $ getEnv "COINBASE_PRO_SECRET"
+        tPass   <- liftM CBS.pack $ getEnv "COINBASE_PRO_PASSPHRASE"
 
-        sbox    <- getEnv "GDAX_SANDBOX"
+        sbox    <- getEnv "COINBASE_PRO_SANDBOX"
         let apiType  = case sbox of
                         "FALSE" -> Live
                         "TRUE"  -> Sandbox

--- a/src/Coinbase/Exchange/Types.hs
+++ b/src/Coinbase/Exchange/Types.hs
@@ -68,19 +68,19 @@ type Endpoint = String
 type Path     = String
 
 website :: Endpoint
-website = "https://public.sandbox.gdax.com"
+website = "https://public.sandbox.pro.coinbase.com"
 
 sandboxRest :: Endpoint
-sandboxRest = "https://api-public.sandbox.gdax.com"
+sandboxRest = "https://api-public.sandbox.pro.coinbase.com"
 
 sandboxSocket :: Endpoint
-sandboxSocket = "ws-feed-public.sandbox.gdax.com"
+sandboxSocket = "ws-feed-public.sandbox.pro.coinbase.com"
 
 liveRest :: Endpoint
-liveRest = "https://api.gdax.com"
+liveRest = "https://api.pro.coinbase.com"
 
 liveSocket :: Endpoint
-liveSocket = "ws-feed.gdax.com"
+liveSocket = "ws-feed.pro.coinbase.com"
 
 -- Coinbase needs to provide real BTC transfers through the exchange API soon,
 -- making 2 API calls with 2 sets of authentication credentials is ridiculous.

--- a/src/Coinbase/Exchange/Types/Private.hs
+++ b/src/Coinbase/Exchange/Types/Private.hs
@@ -423,7 +423,7 @@ instance FromJSON Order where
                 <$> m .: "id"
                 <*> m .: "product_id"
                 <*> m .: "status"
-                <*> m .: "stp"
+                <*> m .:? "stp" .!= DecrementAndCancel
                 <*> m .: "settled"
                 <*> m .: "side"
                 <*> m .: "created_at"

--- a/src/Coinbase/Exchange/Types/Socket.hs
+++ b/src/Coinbase/Exchange/Types/Socket.hs
@@ -97,7 +97,7 @@ data ExchangeMessage
         -- Filled market orders limited by funds will not have a price but may have remaining_size
         -- Filled limit orders may have a price but not a remaining_size (assumed zero)
         -- CURRENTLY ** `remaining_size` reported in Done messages is sometimes incorrect **
-        -- This appears to be bug at GDAX. I've told them about it.
+        -- This appears to be bug at Coinbase. I've told them about it.
         , msgMaybePrice   :: Maybe Price
         , msgMaybeRemSize :: Maybe Size
         }

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -19,11 +19,11 @@ import qualified Coinbase.Exchange.Socket.Test     as Socket
 main :: IO ()
 main = do
         mgr     <- newManager tlsManagerSettings
-        tKey    <- liftM CBS.pack $ getEnv "GDAX_KEY"
-        tSecret <- liftM CBS.pack $ getEnv "GDAX_SECRET"
-        tPass   <- liftM CBS.pack $ getEnv "GDAX_PASSPHRASE"
+        tKey    <- liftM CBS.pack $ getEnv "COINBASE_PRO_KEY"
+        tSecret <- liftM CBS.pack $ getEnv "COINBASE_PRO_SECRET"
+        tPass   <- liftM CBS.pack $ getEnv "COINBASE_PRO_PASSPHRASE"
 
-        sbox    <- getEnv "GDAX_SANDBOX"
+        sbox    <- getEnv "COINBASE_PRO_SANDBOX"
         let apiType  = case sbox of
                         "FALSE" -> Live
                         "TRUE"  -> Sandbox


### PR DESCRIPTION
All of the API calls that return order information (`getOrderList`, `getOrder`, `cancelOrder`, ...) fail when the JSON returned by the server does not contain the optional `stp` field, the "self-trade prevention" parameter. This occurs because the field has a default value and the server doesn't provide the value when it's set to the default.

I've changed the definition of `fromJSON` in the Aeson instance for the `Order` type to allow it to fail while providing a default value, setting it to `DecrementAndCancel`, which corresponds to the implicit `dc` default JSON value.

All the previously failing tests related to this issue now pass.